### PR TITLE
Update to 1.21.4 (#9)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.6-SNAPSHOT'
+    id 'fabric-loom' version '1.11-SNAPSHOT'
 }
 
 version = project.mod_version

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,17 +3,17 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21
-yarn_mappings=1.21+build.2
-loader_version=0.15.11
+minecraft_version=1.21.4
+yarn_mappings=1.21.4+build.2
+loader_version=0.17.2
 
 # Mod Properties
-mod_version=0.0.5+1.21
+mod_version=0.0.5+1.21.4
 maven_group=net.rotgruengelb.your_time
 archives_base_name=your_time
 
 # Dependencies
-modmenu_version=11.0.1
-owo_version=0.12.8-alpha.7+1.21
+modmenu_version=13.0.3
+owo_version=0.12.20+1.21.4
 nixienaut_version=2.0.2
-fabric_version=0.100.3+1.21
+fabric_version=0.119.4+1.21.4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip

--- a/src/main/java/net/rotgruengelb/your_time/Your_Time.java
+++ b/src/main/java/net/rotgruengelb/your_time/Your_Time.java
@@ -1,7 +1,11 @@
 package net.rotgruengelb.your_time;
 
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
+import net.fabricmc.fabric.api.client.rendering.v1.HudLayerRegistrationCallback;
+import net.fabricmc.fabric.api.client.rendering.v1.IdentifiedLayer;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.render.RenderTickCounter;
+import net.minecraft.util.Identifier;
 import net.rotgruengelb.your_time.config.ModConfig;
 import net.rotgruengelb.your_time.events.TimerGuiOverlay;
 import org.slf4j.Logger;
@@ -14,6 +18,17 @@ public class Your_Time implements ClientModInitializer {
 
 	@Override
 	public void onInitializeClient() {
-		HudRenderCallback.EVENT.register(TimerGuiOverlay::renderOverlay);
+		HudLayerRegistrationCallback.EVENT.register(layer ->
+				layer.addLayer(new IdentifiedLayer() {
+					@Override
+					public Identifier id() {
+						return Identifier.of(MOD_ID, "timer_gui_overlay");
+					}
+
+					@Override
+					public void render(DrawContext context, RenderTickCounter tickCounter) {
+						TimerGuiOverlay.renderOverlay(context, tickCounter);
+					}
+				}));
 	}
 }

--- a/src/main/resources/your_time.mixins.json
+++ b/src/main/resources/your_time.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "net.rotgruengelb.your_time.mixin",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
   ],
   "client": [


### PR DESCRIPTION
#modtoberfest

As your last comment in #9 is already over half a year ago you probably aren't thinking about this currently.

Notes:

- No functional changes, mostly dependency updates.
- Updated to a newer version of Fabric API's HUD rendering API
- You might want to create a new branch to target this PR to.
- If you want, there's also a branch for 1.21.9 on the forked repository you can merge as well (up to you). The most notable changes for that are another update to the HUD rendering API and that it is no longer possible to pass transparent color values to minecraft's textrenderer (fixed by using `ColorHelper#fullAlpha`). 

Tiny Sidenote:

- Some changes on your `dev/multiversion` branch will not work in prod as the game is remapped to intermediary. As such you need to use fabric loader's mapping resolver with intermediary names (because there are no named mappings in prod) before using reflection on the game.

Considering this project is moved to your archive organization on modrinth you may of course also close this PR/archive the repo.